### PR TITLE
Allows multiple keywords as conditions

### DIFF
--- a/Editor/MetaDataHelper.cs
+++ b/Editor/MetaDataHelper.cs
@@ -527,13 +527,25 @@ namespace LWGUI
 			var propertyStaticData = lwgui.perShaderData.propertyDatas[prop.name];
 			var propertyDynamicData = lwgui.perFrameData.propertyDatas[prop.name];
 			var displayModeData = lwgui.perShaderData.displayModeData;
+			
+			//if the Conditional Display Keyword is not active
+			if(!string.IsNullOrEmpty(propertyStaticData.conditionalDisplayKeyword))
+			{
+				var keywords = propertyStaticData.conditionalDisplayKeyword.Split(".");
+				
+				var commonElements = material.shaderKeywords.Intersect(keywords);
+				if (!commonElements.Any())
+				{
+					result = false;
+				}
+			}
 
 			if ( // if HideInInspector
 				Helper.IsPropertyHideInInspector(prop)
 				// if Search Filtered
 			 	|| !propertyStaticData.isSearchDisplayed
 				// if the Conditional Display Keyword is not active
-			 	|| (!string.IsNullOrEmpty(propertyStaticData.conditionalDisplayKeyword) && !material.shaderKeywords.Any((str => str == propertyStaticData.conditionalDisplayKeyword)))
+			 	//|| (!string.IsNullOrEmpty(propertyStaticData.conditionalDisplayKeyword) && !material.shaderKeywords.Any((str => str == propertyStaticData.conditionalDisplayKeyword)))
 				|| (!displayModeData.showAllHiddenProperties && propertyStaticData.isHidden)
 				// if show modified only
 				|| (displayModeData.showOnlyModifiedProperties && !propertyDynamicData.hasModified)


### PR DESCRIPTION
Allows multiple keywords as group visiable conditions, it is very useful when a parameter shares same keywords.
![image](https://github.com/JasonMa0012/LWGUI/assets/18584942/400fc381-fb28-4a03-bd9f-8fe85f9a86e1)
![image](https://github.com/JasonMa0012/LWGUI/assets/18584942/68430b77-4aa5-4c38-b795-3d57f934c4ad)
