### PR TITLE
Make sure the preset is applied correctly

### DIFF
--- a/Editor/Helper/PresetHelper.cs
+++ b/Editor/Helper/PresetHelper.cs
@@ -67,6 +67,7 @@ namespace LWGUI
 		public static void ApplyPresetsInMaterial(Material material)
 		{
 			var props = MaterialEditor.GetMaterialProperties(new UnityEngine.Object[] { material });
+			var presets = new List<LwguiShaderPropertyPreset.Preset>();
 			foreach (var prop in props)
 			{
 				var drawer = ReflectionHelper.GetPropertyDrawer(material.shader, prop, out _);
@@ -75,10 +76,15 @@ namespace LWGUI
 				if (drawer is IPresetDrawer presetDrawer)
 				{
 					var activePreset = presetDrawer.GetActivePreset(prop, GetPresetAsset(presetDrawer.GetPresetFileName()));
-					activePreset?.ApplyToDefaultMaterial(material);
+					if (activePreset?.order > -1) presets.Add(activePreset);
 				}
 			}
-			UnityEditorExtension.ApplyMaterialPropertyAndDecoratorDrawers(material);
+			if (presets.Count > 0)
+			{
+				presets.Sort((x, y) => x.order.CompareTo(y.order));
+				foreach (var preset in presets) preset.ApplyToDefaultMaterial(material);
+				UnityEditorExtension.ApplyMaterialPropertyAndDecoratorDrawers(material);
+			}
 		}
 	}
 }

--- a/Editor/ScriptableObject/LwguiShaderPropertyPreset.cs
+++ b/Editor/ScriptableObject/LwguiShaderPropertyPreset.cs
@@ -22,6 +22,9 @@ namespace LWGUI
 			Integer,
 		}
 
+		[SerializeField]
+		public int order;
+
 		[Serializable]
 		public class PropertyValue
 		{
@@ -161,6 +164,7 @@ namespace LWGUI
 			public List<string>        enabledPasses  = new List<string>();
 			public List<string>        disabledPasses = new List<string>();
 			public int                 renderQueue      = -1;
+			public int				   order			= -1;
 
 
 			public void ApplyToDefaultMaterial(Material material)

--- a/Editor/ShaderDrawer.cs
+++ b/Editor/ShaderDrawer.cs
@@ -724,6 +724,7 @@ namespace LWGUI
 			if (lwguiShaderPropertyPreset && index >= 0 && index < lwguiShaderPropertyPreset.GetPresetCount())
 			{
 				preset = lwguiShaderPropertyPreset.GetPreset(index);
+				preset.order = index != 0 ? lwguiShaderPropertyPreset.order : -1;
 			}
 			return preset;
 		}


### PR DESCRIPTION
I found that the presets could not be applied because its organization is very messy.
This commit does two things:

- Provides an "Order" priority for preset to ensure execution order
- Ignores applying all default presets