### PR TITLE
Dev

### DIFF
--- a/Editor/Helper/ContextMenuHelper.cs
+++ b/Editor/Helper/ContextMenuHelper.cs
@@ -19,7 +19,7 @@ namespace LWGUI
 			_copiedMaterial = Object.Instantiate(mat);
 		}
 		
-		public static void DoPasteMaterialProperties(LWGUIMetaDatas metaDatas, uint valueMask)
+		public static void PastePropertiesToMaterials(LWGUIMetaDatas metaDatas, uint valueMask)
 		{
 			if (!_copiedMaterial)
 			{
@@ -37,17 +37,33 @@ namespace LWGUI
 			Undo.RecordObjects(targetMaterials, "LWGUI: Paste Material Properties");
 			foreach (Material material in targetMaterials)
 			{
-				for (int i = 0; i < _copiedMaterial.shader.GetPropertyCount(); i++)
-				{
-					var name = _copiedMaterial.shader.GetPropertyName(i);
-					var type = _copiedMaterial.shader.GetPropertyType(i);
-					PastePropertyValueToMaterial(material, name, name, type, valueMask);
-				}
-				if ((valueMask & (uint)ToolbarHelper.CopyMaterialValueMask.Keyword) != 0)
-					material.shaderKeywords = _copiedMaterial.shaderKeywords;
-				if ((valueMask & (uint)ToolbarHelper.CopyMaterialValueMask.RenderQueue) != 0)
-					material.renderQueue = _copiedMaterial.renderQueue;
+				PastePropertiesToMaterial(material, valueMask);
 			}
+		}
+
+		public static void PastePropertiesToMaterial(Material target, uint valueMask = ToolbarHelper.CopyMaterialValueMaskAll)
+		{
+			if (!_copiedMaterial)
+			{
+				Debug.LogError("LWGUI: Please copy Material Properties first!");
+				return;
+			}
+			if (!VersionControlHelper.Checkout(target))
+			{
+				Debug.LogError("LWGUI: Unable to write material!");
+				return;
+			}
+			Undo.RecordObject(target, "LWGUI: Paste Material Properties");
+			for (int i = 0; i < _copiedMaterial.shader.GetPropertyCount(); i++)
+			{
+				var name = _copiedMaterial.shader.GetPropertyName(i);
+				var type = _copiedMaterial.shader.GetPropertyType(i);
+				PastePropertyValueToMaterial(target, name, name, type, valueMask);
+			}
+			if ((valueMask & (uint)ToolbarHelper.CopyMaterialValueMask.Keyword) != 0)
+				target.shaderKeywords = _copiedMaterial.shaderKeywords;
+			if ((valueMask & (uint)ToolbarHelper.CopyMaterialValueMask.RenderQueue) != 0)
+				target.renderQueue = _copiedMaterial.renderQueue;
 		}
 
 		private static void PastePropertyValueToMaterial(Material material, string srcName, string dstName)

--- a/Editor/Helper/IOHelper.cs
+++ b/Editor/Helper/IOHelper.cs
@@ -144,10 +144,10 @@ namespace LWGUI
 
             if (p.ExitCode != 0)
             {
-                Debug.LogError($"LWGUI: Process Exit Code {p.ExitCode}: {stderr}" +
+				output = stderr.ToString() + output;
+                Debug.LogError($"LWGUI: Process Exit Code {p.ExitCode}: {output}" +
                                $"File: {file}\n" +
                                $"Args: {args}");
-                output = stderr.ToString();
                 return false;
             }
 

--- a/Editor/Helper/RampHelper.cs
+++ b/Editor/Helper/RampHelper.cs
@@ -12,10 +12,13 @@ namespace LWGUI
 	{
 		#region RampEditor
 
-		private static readonly GUIContent _iconAdd     = new GUIContent(EditorGUIUtility.IconContent("d_Toolbar Plus").image, "Add"),
-										   _iconEdit    = new GUIContent(EditorGUIUtility.IconContent("editicon.sml").image, "Edit"),
-										   _iconDiscard = new GUIContent(EditorGUIUtility.IconContent("d_TreeEditor.Refresh").image, "Discard"),
-										   _iconSave    = new GUIContent(EditorGUIUtility.IconContent("SaveActive").image, "Save");
+		private const string _iconCloneGUID = "9cdef444d18d2ce4abb6bbc4fed4d109";
+
+		private static readonly GUIContent _iconAdd     = new (EditorGUIUtility.IconContent("d_Toolbar Plus").image, "Add"),
+										   _iconClone   = new (EditorGUIUtility.IconContent("AnimatorController Icon").image, "Clone"),
+										   _iconEdit    = new (EditorGUIUtility.IconContent("editicon.sml").image, "Edit"),
+										   _iconDiscard = new (EditorGUIUtility.IconContent("d_TreeEditor.Refresh").image, "Discard"),
+										   _iconSave    = new (EditorGUIUtility.IconContent("SaveActive").image, "Save");
 
 		public static void RampEditor(
 			Rect buttonRect,
@@ -27,6 +30,7 @@ namespace LWGUI
 			out bool hasChange,
 			out bool doEditWhenNoGradient,
 			out bool doRegisterUndo,
+			out bool doClone,
 			out bool doCreate,
 			out bool doSave,
 			out bool doDiscard,
@@ -36,11 +40,12 @@ namespace LWGUI
 			var hasNoGradient = gradient == null;
 			var _doEditWhenNoGradient = false;
 			var doOpenWindow = false;
-			var singleButtonWidth = buttonRect.width * 0.25f;
+			var singleButtonWidth = buttonRect.width * 0.2f;
 			var editRect = new Rect(buttonRect.x + singleButtonWidth * 0, buttonRect.y, singleButtonWidth, buttonRect.height);
 			var saveRect = new Rect(buttonRect.x + singleButtonWidth * 1, buttonRect.y, singleButtonWidth, buttonRect.height);
-			var addRect = new Rect(buttonRect.x + singleButtonWidth * 2, buttonRect.y, singleButtonWidth, buttonRect.height);
-			var discardRect = new Rect(buttonRect.x + singleButtonWidth * 3, buttonRect.y, singleButtonWidth, buttonRect.height);
+			var cloneRect = new Rect(buttonRect.x + singleButtonWidth * 2, buttonRect.y, singleButtonWidth, buttonRect.height);
+			var addRect = new Rect(buttonRect.x + singleButtonWidth * 3, buttonRect.y, singleButtonWidth, buttonRect.height);
+			var discardRect = new Rect(buttonRect.x + singleButtonWidth * 4, buttonRect.y, singleButtonWidth, buttonRect.height);
 
 			// Edit button event
 			hasChange = false;
@@ -74,6 +79,8 @@ namespace LWGUI
 			}
 			doEditWhenNoGradient = _doEditWhenNoGradient;
 
+			// Clone button
+			doClone = GUI.Button(cloneRect, _iconClone);
 			
 			// Create button
 			doCreate = GUI.Button(addRect, _iconAdd);
@@ -187,9 +194,9 @@ namespace LWGUI
 			return subJSONs[0] != subJSONs[1];
 		}
 
-		public static bool CreateAndSaveNewGradientTexture(int width, int height, string unityPath, bool isLinear)
+		public static bool CreateAndSaveNewGradientTexture(int width, int height, string unityPath, bool isLinear, LwguiGradient sourceGradient = null)
 		{
-			var gradient = new LwguiGradient();
+			var gradient = sourceGradient != null ? new LwguiGradient(sourceGradient) : new LwguiGradient();
 
 			var ramp = gradient.GetPreviewRampTexture(width, height, ColorSpace.Linear);
 			var png = ramp.EncodeToPNG();

--- a/Editor/Helper/ToolbarHelper.cs
+++ b/Editor/Helper/ToolbarHelper.cs
@@ -23,6 +23,8 @@ namespace LWGUI
             All         = (1 << 5) - 1,
         }
 
+        public const uint CopyMaterialValueMaskAll = (uint)CopyMaterialValueMask.All;
+
         private static GUIContent[] _pasteMaterialMenus = new[]
         {
             new GUIContent("Paste Number Values"),
@@ -102,13 +104,13 @@ namespace LWGUI
                 && buttonRect.Contains(Event.current.mousePosition))
             {
                 EditorUtility.DisplayCustomMenu(new Rect(Event.current.mousePosition.x, Event.current.mousePosition.y, 0, 0), _pasteMaterialMenus, -1,
-                    (data, options, selected) => { ContextMenuHelper.DoPasteMaterialProperties(metaDatas, _pasteMaterialMenuValueMasks[selected]); }, null);
+                    (data, options, selected) => { ContextMenuHelper.PastePropertiesToMaterials(metaDatas, _pasteMaterialMenuValueMasks[selected]); }, null);
                 Event.current.Use();
             }
             // Left Click
             if (GUI.Button(buttonRect, _guiContentPaste, GUIStyles.iconButton))
             {
-                ContextMenuHelper.DoPasteMaterialProperties(metaDatas, (uint)CopyMaterialValueMask.All);
+                ContextMenuHelper.PastePropertiesToMaterials(metaDatas, (uint)CopyMaterialValueMask.All);
             }
 
             //----------------------------------------------------------------------------------------------------------------
@@ -247,6 +249,11 @@ namespace LWGUI
         }
 
         public static Func<Renderer, Material, Material> onFindMaterialAssetInRendererByMaterialInstance;
+
+        public static bool FindMaterialAsset(LWGUIMetaDatas metaDatas, out Material materialAsset)
+        {
+            return FindMaterialAssetByMaterialInstance(metaDatas.GetMaterial(), metaDatas, out materialAsset);
+        }
 
         private static bool FindMaterialAssetByMaterialInstance(Material material, LWGUIMetaDatas metaDatas, out Material materialAsset)
         {

--- a/Editor/LWGUI.cs
+++ b/Editor/LWGUI.cs
@@ -7,6 +7,7 @@ using UnityEngine.Rendering;
 namespace LWGUI
 {
 	public delegate void LWGUICustomGUIEvent(LWGUI lwgui);
+	public delegate void LWGUIToolbarExtensionEvent(LWGUI lwgui, ref Rect toolBarRect);
 
 	public class LWGUI : ShaderGUI
 	{
@@ -15,6 +16,8 @@ namespace LWGUI
 
 		public static LWGUICustomGUIEvent onDrawCustomHeader;
 		public static LWGUICustomGUIEvent onDrawCustomFooter;
+		public static LWGUIToolbarExtensionEvent onDrawToolbarLeft;
+		public static LWGUIToolbarExtensionEvent onDrawToolbarRight;
 
 		/// <summary>
 		/// Called when switch to a new Material Window, each window has a LWGUI instance
@@ -50,7 +53,9 @@ namespace LWGUI
 				var toolBarRect = EditorGUILayout.GetControlRect();
 				toolBarRect.xMin = 2;
 
+				onDrawToolbarLeft?.Invoke(this, ref toolBarRect);
 				ToolbarHelper.DrawToolbarButtons(ref toolBarRect, metaDatas);
+				onDrawToolbarRight?.Invoke(this, ref toolBarRect);
 				ToolbarHelper.DrawSearchField(toolBarRect, metaDatas);
 
 				GUILayoutUtility.GetRect(0, 0); // Space(0)

--- a/Editor/PerformanceMonitor/ShaderCompiler/Mali/Models/JsonMaliocOutput.cs
+++ b/Editor/PerformanceMonitor/ShaderCompiler/Mali/Models/JsonMaliocOutput.cs
@@ -8,13 +8,27 @@ namespace LWGUI.PerformanceMonitor.ShaderCompiler.Mali
     [Serializable]
     internal class JsonMaliocOutput
     {
+        public Schema schema;
         public Shader[] shaders;
+
+        [Serializable]
+        public class Schema
+        {
+            public string name;
+            public int version;
+        }
 
         [Serializable]
         public class Shader
         {
+            // Normal output fields
             public ShaderProperty[] properties;
             public ShaderVariant[] variants;
+
+            // Error output fields
+            public string[] errors;
+            public string[] warnings;
+            public string filename;
         }
 
         [Serializable]

--- a/Editor/PerformanceMonitor/ShaderCompiler/Mali/Models/RuntimeMaliocShader.cs
+++ b/Editor/PerformanceMonitor/ShaderCompiler/Mali/Models/RuntimeMaliocShader.cs
@@ -18,6 +18,9 @@ namespace LWGUI.PerformanceMonitor.ShaderCompiler.Mali
             Texture,
         }
 
+        public bool HasErrors;
+        public List<string> Errors;
+        public List<string> Warnings;
         public List<ShaderProperty> Properties;
         public List<ShaderVariant> Variants;
 

--- a/Editor/PerformanceMonitor/ShaderCompiler/Mali/Parsing/MaliocOutputParser.cs
+++ b/Editor/PerformanceMonitor/ShaderCompiler/Mali/Parsing/MaliocOutputParser.cs
@@ -33,8 +33,25 @@ namespace LWGUI.PerformanceMonitor.ShaderCompiler.Mali
 
             var shader = jsonModel.shaders[0];
 
+            // Check if this is an error response
+            bool isErrorResponse = jsonModel.schema?.name == "error";
+            if (isErrorResponse || (shader.errors != null && shader.errors.Length > 0))
+            {
+                return new RuntimeMaliocShader
+                {
+                    HasErrors = true,
+                    Errors = shader.errors?.ToList() ?? new System.Collections.Generic.List<string>(),
+                    Warnings = shader.warnings?.ToList() ?? new System.Collections.Generic.List<string>(),
+                    Properties = new System.Collections.Generic.List<RuntimeMaliocShader.ShaderProperty>(),
+                    Variants = new System.Collections.Generic.List<RuntimeMaliocShader.ShaderVariant>(),
+                };
+            }
+
             return new RuntimeMaliocShader
             {
+                HasErrors = false,
+                Errors = new System.Collections.Generic.List<string>(),
+                Warnings = shader.warnings?.ToList() ?? new System.Collections.Generic.List<string>(),
                 Properties = shader.properties.Select(ConvertProperty).ToList(),
                 Variants = shader.variants.Select(variant =>
                     {

--- a/Editor/PerformanceMonitor/ShaderCompiler/Mali/ShaderCompilerMali.cs
+++ b/Editor/PerformanceMonitor/ShaderCompiler/Mali/ShaderCompilerMali.cs
@@ -76,8 +76,8 @@ namespace LWGUI.PerformanceMonitor.ShaderCompiler
             compiledShader = Encoding.UTF8.GetString(compileInfo.ShaderData);
 
             // Fix Mali Compiler Errors
-            // compiledShader = compiledShader.Replace("#version 300 es", "#version 320 es");
-            // compiledShader = compiledShader.Replace("#version 310 es", "#version 320 es");
+            compiledShader = compiledShader.Replace("#version 300 es", "#version 320 es");
+            compiledShader = compiledShader.Replace("#version 310 es", "#version 320 es");
             IOHelper.WriteTextFile(shaderPerfData.compiledShaderPath, compiledShader);
 
             return !string.IsNullOrWhiteSpace(compiledShader);

--- a/Editor/PerformanceMonitor/ShaderCompiler/Mali/ShaderCompilerMali.cs
+++ b/Editor/PerformanceMonitor/ShaderCompiler/Mali/ShaderCompilerMali.cs
@@ -76,7 +76,8 @@ namespace LWGUI.PerformanceMonitor.ShaderCompiler
             compiledShader = Encoding.UTF8.GetString(compileInfo.ShaderData);
 
             // Fix Mali Compiler Errors
-            compiledShader = compiledShader.Replace("#version 300 es", "#version 320 es");
+            // compiledShader = compiledShader.Replace("#version 300 es", "#version 320 es");
+            // compiledShader = compiledShader.Replace("#version 310 es", "#version 320 es");
             IOHelper.WriteTextFile(shaderPerfData.compiledShaderPath, compiledShader);
 
             return !string.IsNullOrWhiteSpace(compiledShader);
@@ -117,41 +118,53 @@ namespace LWGUI.PerformanceMonitor.ShaderCompiler
         {
             EditorGUILayout.BeginHorizontal();
 
-            if (shaderPerfData.stats is RuntimeMaliocShader { Variants: { Count: > 0 } } stats
-                && stats.Variants[0].Pipelines is { Count : > 0 })
+            if (shaderPerfData.stats is RuntimeMaliocShader stats)
             {
-                var variant = stats.Variants[0];
-                var cycles = Enumerable.Repeat(0.0f, variant.Pipelines.Count).ToList();
-
-                for (int i = 0; i < variant.Pipelines.Count; i++)
+                if (stats.Variants is { Count: > 0 } && stats.Variants[0].Pipelines is { Count: > 0 })
                 {
-                    cycles[i] = Mathf.Max(Mathf.Max(variant.ShortestPathCycles.PipelineCycles[i],
-                            variant.LongestPathCycles.PipelineCycles[i]),
-                        variant.TotalCycles.PipelineCycles[i]);
-                }
+                    var variant = stats.Variants[0];
+                    var cycles = Enumerable.Repeat(0.0f, variant.Pipelines.Count).ToList();
 
-                // https://developer.arm.com/documentation/101863/8-8/Using-Mali-Offline-Compiler/Performance-analysis/Performance-table
-                float arithmeticCycle = 0;
-                float loadStoreCycle = 0;
-                float varyingCycle = 0;
-                float textureCycle = 0;
-                for (int i = 0; i < variant.Pipelines.Count; i++)
-                {
-                    switch (variant.Pipelines[i])
+                    for (int i = 0; i < variant.Pipelines.Count; i++)
                     {
-                        case RuntimeMaliocShader.ShaderVariantPipelineType.Arithmetic: arithmeticCycle = cycles[i]; break;
-                        case RuntimeMaliocShader.ShaderVariantPipelineType.LoadStore:  loadStoreCycle = cycles[i]; break;
-                        case RuntimeMaliocShader.ShaderVariantPipelineType.Varying:    varyingCycle = cycles[i]; break;
-                        case RuntimeMaliocShader.ShaderVariantPipelineType.Texture:    textureCycle = cycles[i]; break;
+                        cycles[i] = Mathf.Max(Mathf.Max(variant.ShortestPathCycles.PipelineCycles[i],
+                                variant.LongestPathCycles.PipelineCycles[i]),
+                            variant.TotalCycles.PipelineCycles[i]);
                     }
+
+                    // https://developer.arm.com/documentation/101863/8-8/Using-Mali-Offline-Compiler/Performance-analysis/Performance-table
+                    float arithmeticCycle = 0;
+                    float loadStoreCycle = 0;
+                    float varyingCycle = 0;
+                    float textureCycle = 0;
+                    for (int i = 0; i < variant.Pipelines.Count; i++)
+                    {
+                        switch (variant.Pipelines[i])
+                        {
+                            case RuntimeMaliocShader.ShaderVariantPipelineType.Arithmetic: arithmeticCycle = cycles[i]; break;
+                            case RuntimeMaliocShader.ShaderVariantPipelineType.LoadStore:  loadStoreCycle = cycles[i]; break;
+                            case RuntimeMaliocShader.ShaderVariantPipelineType.Varying:    varyingCycle = cycles[i]; break;
+                            case RuntimeMaliocShader.ShaderVariantPipelineType.Texture:    textureCycle = cycles[i]; break;
+                        }
+                    }
+
+                    var statsStr = $"{arithmeticCycle,8:0.0} {loadStoreCycle,9:0.0} {varyingCycle,7:0.0} {textureCycle,6:0.0}";
+                    EditorGUILayout.LabelField($"{shaderPerfData.passName} | {shaderPerfData.shaderTypeName}", statsStr, GUIStyles.label_monospace);
+
+                    ToolbarHelper.DrawShaderPerformanceStatsLineButtons(shaderPerfData);
+                    if (GUILayout.Button("Json", GUILayout.MaxWidth(40)))
+                        IOHelper.OpenFile(GetMaliJsonOutputPath(shaderPerfData));
                 }
-
-                var statsStr = $"{arithmeticCycle,8:0.0} {loadStoreCycle,9:0.0} {varyingCycle,7:0.0} {textureCycle,6:0.0}";
-                EditorGUILayout.LabelField($"{shaderPerfData.passName} | {shaderPerfData.shaderTypeName}", statsStr, GUIStyles.label_monospace);
-
-                ToolbarHelper.DrawShaderPerformanceStatsLineButtons(shaderPerfData);
-                if (GUILayout.Button("Json", GUILayout.MaxWidth(40)))
-                    IOHelper.OpenFile(GetMaliJsonOutputPath(shaderPerfData));
+                else
+                {
+                    EditorGUILayout.LabelField($"{shaderPerfData.passName} | {shaderPerfData.shaderTypeName}", "ANALYSIS FAILED");
+                }
+                
+                if (stats.HasErrors)
+                {
+					var errorMsg = stats.Errors.Count > 0 ? stats.Errors[0] : "Unknown Error";
+					Debug.LogError($"LWGUI: {shaderPerfData.passName} | {shaderPerfData.shaderTypeName} Error:\n{errorMsg}");
+                }
             }
             else
             {

--- a/Editor/ScriptableObject/LwguiRampAtlas.cs
+++ b/Editor/ScriptableObject/LwguiRampAtlas.cs
@@ -151,15 +151,18 @@ namespace LWGUI
 
 		public int TotalRowCount => RampCount * RowCountPerRamp;
 
-		public virtual IRamp CreateRamp()
+		public virtual IRamp CreateRamp(IRamp srcRamp = null)
 		{
-			return new Ramp();
+			var newRamp = new Ramp();
+			if (srcRamp != null)
+				newRamp.CopyFrom(srcRamp);
+			return newRamp;
 		}
 
-		public virtual IRamp AddRamp()
+		public virtual IRamp AddRamp(IRamp srcRamp = null)
 		{
 			_ramps ??= new List<Ramp>();
-			var newRamp = CreateRamp();
+			var newRamp = CreateRamp(srcRamp);
 			_ramps.Add(newRamp as Ramp);
 			return newRamp;
 		}

--- a/Editor/ShaderDrawers/ExtraDrawers/Texture/RampAtlasIndexerDrawer.cs
+++ b/Editor/ShaderDrawers/ExtraDrawers/Texture/RampAtlasIndexerDrawer.cs
@@ -134,18 +134,22 @@ namespace LWGUI
 				return null;
 		}
 
-		protected override void CreateNewRampMap(MaterialProperty prop, MaterialEditor editor)
+		protected override void CloneRampMap(MaterialProperty prop, MaterialEditor editor, LwguiGradient gradient)
 		{
-			// Create a Ramp
+			// Create or Clone a Ramp
 			if (rampAtlasSO)
 			{
+				bool shouldCreateRamp = gradient == null || _currentRamp == null;
 				var newIndex = rampAtlasSO.RampCount;
+				var newRamp = rampAtlasSO.AddRamp(shouldCreateRamp ? null : _currentRamp);
 
-				var newRamp = rampAtlasSO.AddRamp();
-				newRamp.Name = defaultRampName;
-				newRamp.ColorSpace = colorSpace;
-				newRamp.ChannelMask = viewChannelMask;
-				newRamp.TimeRange = timeRange;
+				if (shouldCreateRamp)
+				{
+					newRamp.Name = defaultRampName;
+					newRamp.ColorSpace = colorSpace;
+					newRamp.ChannelMask = viewChannelMask;
+					newRamp.TimeRange = timeRange;
+				}
 
 				prop.SetNumericValue(newIndex);
 

--- a/Editor/ShaderDrawers/ExtraDrawers/Texture/RampDrawer.cs
+++ b/Editor/ShaderDrawers/ExtraDrawers/Texture/RampDrawer.cs
@@ -122,6 +122,11 @@ namespace LWGUI
 		
 		protected virtual void CreateNewRampMap(MaterialProperty prop, MaterialEditor editor)
 		{
+			CloneRampMap(prop, editor, null);
+		}
+
+		protected virtual void CloneRampMap(MaterialProperty prop, MaterialEditor editor, LwguiGradient gradient)
+		{
 			string createdFileRelativePath = string.Empty;
 			while (true)
 			{
@@ -151,8 +156,11 @@ namespace LWGUI
 
 			if (!string.IsNullOrEmpty(createdFileRelativePath))
 			{
-				RampHelper.CreateAndSaveNewGradientTexture(defaultWidth, defaultHeight, createdFileRelativePath, colorSpace == ColorSpace.Linear);
+				var width = prop.textureValue != null ? prop.textureValue.width : defaultWidth;
+				var height = prop.textureValue != null ? prop.textureValue.height : defaultHeight;
+				RampHelper.CreateAndSaveNewGradientTexture(width, height, createdFileRelativePath, colorSpace == ColorSpace.Linear, gradient);
 				prop.textureValue = AssetDatabase.LoadAssetAtPath<Texture2D>(createdFileRelativePath);
+				EditorGUIUtility.PingObject(prop.textureValue);
 			}
 		}
 
@@ -240,6 +248,7 @@ namespace LWGUI
 				out bool hasGradientChanges, 
 				out bool doEditWhenNoGradient, 
 				out doRegisterUndo, 
+				out bool doClone,
 				out bool doCreate, 
 				out bool doSaveGradient, 
 				out bool doDiscardGradient,
@@ -249,6 +258,15 @@ namespace LWGUI
 			if (doEditWhenNoGradient)
 			{
 				EditWhenNoRampMap(prop, editor);
+			}
+
+			// Clone
+			if (doClone)
+			{
+				LwguiGradientWindow.CloseWindow();
+				CloneRampMap(prop, editor, gradient);
+				OnCreateNewRampMap(prop);
+				LWGUI.OnValidate(metaDatas);
 			}
 			
 			// Create

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.jasonma.lwgui",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "displayName": "LWGUI",
   "description": "A Lightweight, Flexible, Powerful Shader GUI System for Unity.",
   "keywords": [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes touch several Unity Editor workflows (ramp creation/atlas mutation, material property paste, and shader perf parsing/display), so regressions would mainly affect editor UX and diagnostics rather than runtime behavior.
> 
> **Overview**
> Adds **ramp cloning** to the ramp editor UI (new Clone button) and wires it through `RampDrawer`/`RampAtlasIndexerDrawer`/`LwguiRampAtlas` so users can duplicate existing ramps/gradients when creating new ramp maps or atlas entries (including preserving texture dimensions and pinging the new asset).
> 
> Refactors material property paste into `ContextMenuHelper.PastePropertiesToMaterials` + reusable `PastePropertiesToMaterial`, exposes `ToolbarHelper.CopyMaterialValueMaskAll`, and adds `LWGUI` toolbar extension hooks (`onDrawToolbarLeft`/`onDrawToolbarRight`) plus a public `ToolbarHelper.FindMaterialAsset` helper.
> 
> Improves Mali shader performance analysis robustness by parsing malioc error-schema output (`schema`, `errors`/`warnings`) into `RuntimeMaliocShader`, surfacing failures in the stats UI, and expanding GLSL version fixups to include `#version 310 es`; also tweaks `IOHelper.RunProcess` to include stderr in the returned output on failures. Updates package version to `1.32.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d44d693a8276de2f57c320bbf22181d25e1539bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->