### PR TITLE
Add "Copy Material Name" context menu

### DIFF
--- a/Editor/Helper/ContextMenuHelper.cs
+++ b/Editor/Helper/ContextMenuHelper.cs
@@ -7,8 +7,36 @@ using UnityEngine.Rendering;
 
 namespace LWGUI
 {
-    public class ContextMenuHelper
+    public static class ContextMenuHelper
     {
+	    #region Material Context Menu
+		
+	    [MenuItem("CONTEXT/Material/Reimport Shader", false, 100)]
+	    static void MenuItem_ReimportShader(MenuCommand command)
+	    {
+		    var mat = command.context as Material;
+		    if (mat != null)
+		    {
+			    var path = AssetDatabase.GetAssetPath(mat.shader);
+			    if (!string.IsNullOrEmpty(path))
+			    {
+				    AssetDatabase.ImportAsset(path);
+			    }
+		    }
+	    }
+
+	    [MenuItem("CONTEXT/Material/Copy Material Name", false, 990)]
+	    static void MenuItem_CopyMaterialName(MenuCommand command)
+	    {
+		    var mat = command.context as Material;
+		    if (mat != null)
+		    {
+			    GUIUtility.systemCopyBuffer = mat.name;
+		    }
+	    }
+
+	    #endregion
+	    
 		#region Copy and Paste
 		
 		private static Material     _copiedMaterial;

--- a/Editor/LWGUI.cs
+++ b/Editor/LWGUI.cs
@@ -238,19 +238,5 @@ namespace LWGUI
 				if (!hasChange) hasChange = true;
 			}
 		}
-		
-		[MenuItem("CONTEXT/Material/Reimport Shader", false, 100)]
-		static void MenuItem_ReimportShader(MenuCommand command)
-		{
-			var mat = command.context as Material;
-			if (mat != null)
-			{
-				var path = AssetDatabase.GetAssetPath(mat.shader);
-				if (!string.IsNullOrEmpty(path))
-				{
-					AssetDatabase.ImportAsset(path);
-				}
-			}
-		}
 	}
 }

--- a/Editor/ShaderDrawers/ExtraDrawers/Numeric/BitMaskDrawer.cs
+++ b/Editor/ShaderDrawers/ExtraDrawers/Numeric/BitMaskDrawer.cs
@@ -104,8 +104,8 @@ namespace LWGUI
 			int controlId = GUIUtility.GetControlID(_hint, FocusType.Keyboard, position);
 			var fieldRect = EditorGUI.PrefixLabel(position, controlId, label);
 			
-			if (position.width < totalButtonWidth) 
-				return;
+			// if (position.width < totalButtonWidth) 
+			// 	return;
 
 			fieldRect.xMin = fieldRect.xMax;
 			

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.jasonma.lwgui",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "displayName": "LWGUI",
   "description": "A Lightweight, Flexible, Powerful Shader GUI System for Unity.",
   "keywords": [


### PR DESCRIPTION
When the width is insufficient, BitMask() will always display